### PR TITLE
Ensure only a single image is captured automatically

### DIFF
--- a/DocumentScanner/Classes/Scanner/AVDocumentScanner.swift
+++ b/DocumentScanner/Classes/Scanner/AVDocumentScanner.swift
@@ -109,8 +109,12 @@ extension AVDocumentScanner: AVCaptureVideoDataOutputSampleBufferDelegate {
         let (smoothed, newFeatures) = feature.smoothed(with: lastFeatures)
         lastFeatures = newFeatures
 
-        if newFeatures.count > 7, newFeatures.jitter < desiredJitter,
+        if newFeatures.count > 7,
+            newFeatures.jitter < desiredJitter,
+            isStopped == false,
             let delegate = delegate {
+
+            pause()
 
             captureImage(in: smoothed) { [weak delegate] image in
                 delegate?.didCapture(image: image)


### PR DESCRIPTION
We have some reports that the delegate call `didCaptureImage` can be called multiple times when the scanner is set to automatic mode.

This Pull Request ensures that this can never happen again by setting the `isStopped` boolean when calling the completion delegate method.