### PR TITLE
Swift 4.2 migration

### DIFF
--- a/DocumentScanner.podspec
+++ b/DocumentScanner.podspec
@@ -21,10 +21,10 @@ Pod::Spec.new do |s|
 This pod contains a ready to use view controller for document scanning.
                        DESC
 
-  s.homepage         = 'https://github.com/adorsys/document-scanner-ios'
+  s.homepage         = 'https://github.com/adorsys/document-scanner-ios.git'
   s.license          = { :type => 'Apache License 2.0', :file => 'LICENSE' }
   s.author           = { 'xaverlohmueller' => 'xlo@adorsys.de', 'steffen blümm' => 'sbl@adorsys.de' }
-  s.source           = { :git => 'https://github.com/adorsys/document-scanner-ios', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/adorsys/document-scanner-ios.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '10.0'
   s.swift_version = '4.2'

--- a/DocumentScanner.podspec
+++ b/DocumentScanner.podspec
@@ -27,7 +27,7 @@ This pod contains a ready to use view controller for document scanning.
   s.source           = { :git => 'https://github.com/adorsys/document-scanner-ios', :tag => s.version.to_s }
 
   s.ios.deployment_target = '10.0'
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
+  s.swift_version = '4.2'
 
   s.source_files = 'DocumentScanner/Classes/**/*'
   s.resource_bundles = {

--- a/DocumentScanner/Classes/ViewController/Custom Views/TorchPickerView.swift
+++ b/DocumentScanner/Classes/ViewController/Custom Views/TorchPickerView.swift
@@ -54,7 +54,7 @@ final class TorchPickerView: UIView {
     }
 
     private func setupBlurIfNeeded() -> UIVisualEffectView? {
-        guard !UIAccessibilityIsReduceTransparencyEnabled()
+        guard !UIAccessibility.isReduceTransparencyEnabled
             else { backgroundColor = .black; return nil }
 
         backgroundColor = .clear

--- a/DocumentScanner/Classes/ViewController/ForceTouchRecognizer.swift
+++ b/DocumentScanner/Classes/ViewController/ForceTouchRecognizer.swift
@@ -50,7 +50,7 @@ final class ForceTouchGestureRecognizer: UIGestureRecognizer {
         normalizeForceAndFireEvent(.cancelled, touches: touches)
     }
 
-    private func normalizeForceAndFireEvent(_ state: UIGestureRecognizerState, touches: Set<UITouch>) {
+    private func normalizeForceAndFireEvent(_ state: UIGestureRecognizer.State, touches: Set<UITouch>) {
         guard let firstTouch = touches.first else { return }
 
         maximumForce = min(firstTouch.maximumPossibleForce, maximumForce)

--- a/DocumentScanner/Classes/ViewController/ScannerViewController.swift
+++ b/DocumentScanner/Classes/ViewController/ScannerViewController.swift
@@ -46,7 +46,7 @@ public final class ScannerViewController: UIViewController {
         layer.fillColor = previewColor.withAlphaComponent(0.3).cgColor
         layer.strokeColor = previewColor.withAlphaComponent(0.9).cgColor
         layer.lineWidth = 2
-        layer.contentsGravity = "resizeAspectFill"
+        layer.contentsGravity = .resizeAspectFill
         return layer
     }()
 

--- a/Example/DocumentScannerApp.xcodeproj/project.pbxproj
+++ b/Example/DocumentScannerApp.xcodeproj/project.pbxproj
@@ -202,9 +202,11 @@
 				TargetAttributes = {
 					B23598EE2097134700813B39 = {
 						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1000;
 					};
 					B23599022097134800813B39 = {
 						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1000;
 						TestTargetID = B23598EE2097134700813B39;
 					};
 				};
@@ -501,7 +503,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = de.adorsys.DocumentScannerApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -520,7 +522,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = de.adorsys.DocumentScannerApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
@@ -541,7 +543,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = de.adorsys.DocumentScannerAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DocumentScannerApp.app/DocumentScannerApp";
 			};
@@ -563,7 +565,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = de.adorsys.DocumentScannerAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DocumentScannerApp.app/DocumentScannerApp";
 			};

--- a/Example/DocumentScannerApp/AppDelegate.swift
+++ b/Example/DocumentScannerApp/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         return true
     }

--- a/Example/DocumentScannerApp/ViewController.swift
+++ b/Example/DocumentScannerApp/ViewController.swift
@@ -30,7 +30,6 @@ class ViewController: UIViewController {
 
     // MARK: Init
     required init?(coder aDecoder: NSCoder) {
-
         super.init(coder: aDecoder)
     }
 
@@ -104,10 +103,8 @@ extension ViewController {
     }
 
     @IBAction func editImage(_ sender: UIButton) {
-        guard let image = self.scannedImage else {
-            return
-
-        }
+        guard let image = self.scannedImage
+            else { return }
 
         let cropViewController = TOCropViewController(image: image)
         cropViewController.delegate = self

--- a/Example/DocumentScannerApp/Views/IconButton.swift
+++ b/Example/DocumentScannerApp/Views/IconButton.swift
@@ -80,7 +80,7 @@ class IconButton: UIButton {
         let paragraph = NSMutableParagraphStyle()
         paragraph.lineBreakMode = .byWordWrapping
 
-        var attributes: [NSAttributedStringKey: Any] = [:]
+        var attributes: [NSAttributedString.Key: Any] = [:]
         attributes[.font] = UIFont.systemFont(ofSize: 18)
         attributes[.foregroundColor] = drawColour
         attributes[.paragraphStyle] = paragraph

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - DocumentScanner (1.0.0)
-  - SwiftLint (0.25.0)
-  - TOCropViewController (2.3.6)
+  - SwiftLint (0.27.0)
+  - TOCropViewController (2.3.8)
 
 DEPENDENCIES:
   - DocumentScanner (from `../`)
@@ -18,9 +18,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  DocumentScanner: fb9318d9ae3e96b7c24137b49b7728862599a5df
-  SwiftLint: e14651157288e9e01d6e1a71db7014fb5744a8ea
-  TOCropViewController: 6d972f2c609372312648f96758e13a7f689efbc0
+  DocumentScanner: 2c478a4a27fa226a678476904dfc59b7664ab222
+  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
+  TOCropViewController: 0a075f02c253e88095143bbac7b013fc6fba5090
 
 PODFILE CHECKSUM: e3e22dedac36f1cd6edd0e524210df6b12095f94
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DocumentScanner
 
-[![Swift 4.0](https://img.shields.io/badge/Swift-4.0-orange.svg)](https://swift.org)
+[![Swift 4.2](https://img.shields.io/badge/Swift-4.2-orange.svg)](https://swift.org)
 [![license](https://img.shields.io/badge/license-Apache_2.0-lightgrey.svg)](https://github.com/adorsys/document-scanner-ios/blob/master/LICENSE)
 [![platform](https://img.shields.io/badge/platform-iOS_10+-lightgrey.svg)](https://img.shields.io/badge/platform-iOS_10+-lightgrey.svg)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ back to the default value.
 The scanner's UI can be configured using the initializer:
 
 ```swift
-ScannerViewController(config: [.all])
+ScannerViewController(config: [.torch, .manualCapture])
 ```
 
 The following options are available:


### PR DESCRIPTION
## Description

Run the Xcode migrator for Swift 4.2 and update dependencies.

## ⚠️ Notice

This is just raises the `SWIFT_VERSION` to `4.2` and does not use any new features.