### PR TITLE
Automatically use latest tag on branch as version

### DIFF
--- a/DocumentScanner.podspec
+++ b/DocumentScanner.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'DocumentScanner'
-  s.version          = '1.0.0'
+  s.version          = `git describe --tags`
   s.summary          = 'adorsys Document Scanner (incl. View Controller)'
 
 # This description is used to generate tags and improve search results.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+## Release to Cocoapods
+
+0. Ensure the validation passes
+
+`pod lib lint`
+
+1. Tag the release
+
+`git tag 1.0.0`
+`git push --tags`
+
+2. Submit to Cocoapods Trunk
+
+Before you can do this, register yourself with trunk [according to this guide][1].
+
+`pod trunk push DocumentScanner.podspec`
+
+3. (Optional) Push to In-House Repo
+
+`pod repo push csi-podspecs DocumentScanner.podspec`
+
+You can find more info about releasing [here][2].
+
+
+[1]: https://guides.cocoapods.org/making/getting-setup-with-trunk.html#getting-started
+[2]: https://guides.cocoapods.org/making/making-a-cocoapod.html


### PR DESCRIPTION
## Description

The latest git tag will now be used as the `s.version` parameter in the `.podspec` file.
[SwiftLint][] does a similar thing in their pod spec file, but imo extracting the one liner script is overkill.

The 'script' requires git to be installed on the build machine, but since we have to build on macOS, this should always be met

## ⚠️ Do not forget

Actually tag a version before running `pod lib lint` and the like.
It will fail on branches that don't have any tags.

[SwiftLint]: https://github.com/realm/SwiftLint/blob/master/SwiftLint.podspec