### PR TITLE
Add Carthage compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Swift 4.2](https://img.shields.io/badge/Swift-4.2-orange.svg)](https://swift.org)
 [![license](https://img.shields.io/badge/license-Apache_2.0-lightgrey.svg)](https://github.com/adorsys/document-scanner-ios/blob/master/LICENSE)
 [![platform](https://img.shields.io/badge/platform-iOS_10+-lightgrey.svg)](https://img.shields.io/badge/platform-iOS_10+-lightgrey.svg)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 
 This pod contains a ready to use view controller for document scanning. Yes we scan! 

--- a/Sources/Classes/Maths/Operators.swift
+++ b/Sources/Classes/Maths/Operators.swift
@@ -1,3 +1,5 @@
+import CoreGraphics
+
 extension CGPoint {
     static func + (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
         return CGPoint(x: lhs.x + rhs.x,

--- a/Sources/Classes/Maths/RectangleFeature.swift
+++ b/Sources/Classes/Maths/RectangleFeature.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 struct RectangleFeature {
     let topLeft: CGPoint
     let topRight: CGPoint

--- a/Sources/Classes/Maths/[RectangleFeature]+Extensions.swift
+++ b/Sources/Classes/Maths/[RectangleFeature]+Extensions.swift
@@ -1,3 +1,5 @@
+import CoreGraphics
+
 extension Array where Element == RectangleFeature {
     // Difference of all elements vs. average
     var jitter: CGFloat {

--- a/Sources/Classes/Scanner/AVDocumentScanner.swift
+++ b/Sources/Classes/Scanner/AVDocumentScanner.swift
@@ -1,5 +1,5 @@
 import AVFoundation
-import CoreMedia
+import UIKit
 
 final class AVDocumentScanner: NSObject {
     var lastTorchLevel: Float = 0

--- a/Sources/Classes/Scanner/DocumentScanner.swift
+++ b/Sources/Classes/Scanner/DocumentScanner.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import UIKit
 
 protocol DocumentScanner {
 

--- a/Sources/Classes/Scanner/DocumentScannerDelegate.swift
+++ b/Sources/Classes/Scanner/DocumentScannerDelegate.swift
@@ -1,3 +1,6 @@
+import UIKit
+import CoreImage
+
 protocol DocumentScannerDelegate: class {
     // Always called on main queue
     func didCapture(image: UIImage)

--- a/Sources/Classes/Scanner/ImageCapturer.swift
+++ b/Sources/Classes/Scanner/ImageCapturer.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import UIKit
 
 final class ImageCapturer: NSObject {
     private var feature: RectangleFeature?

--- a/Sources/Classes/ViewController/ScannerViewController+UIElements.swift
+++ b/Sources/Classes/ViewController/ScannerViewController+UIElements.swift
@@ -1,9 +1,4 @@
-//
-//  ScannerViewController+UIElements.swift
-//  DocumentScanner
-//
-//  Created by Xaver Lohmueller on 25.09.17.
-//
+import UIKit
 
 extension ScannerViewController {
     func makeTargetBraceButton() -> UIView {

--- a/Sources/Supporting Files/Info.plist
+++ b/Sources/Supporting Files/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/YesWeScan.xcodeproj/project.pbxproj
+++ b/YesWeScan.xcodeproj/project.pbxproj
@@ -1,0 +1,659 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4EDFAC3D2170E3E100B1402A /* YesWeScan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EDFAC332170E3E100B1402A /* YesWeScan.framework */; };
+		4EDFAC652170E43C00B1402A /* RectangleFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC502170E43C00B1402A /* RectangleFeature.swift */; };
+		4EDFAC662170E43C00B1402A /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC512170E43C00B1402A /* Operators.swift */; };
+		4EDFAC672170E43C00B1402A /* [RectangleFeature]+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC522170E43C00B1402A /* [RectangleFeature]+Extensions.swift */; };
+		4EDFAC682170E43C00B1402A /* UIImage+ScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC542170E43C00B1402A /* UIImage+ScannerViewController.swift */; };
+		4EDFAC692170E43C00B1402A /* ScannerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC552170E43C00B1402A /* ScannerConfig.swift */; };
+		4EDFAC6A2170E43C00B1402A /* ScannerViewController+UIElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC562170E43C00B1402A /* ScannerViewController+UIElements.swift */; };
+		4EDFAC6B2170E43C00B1402A /* ScannerViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC572170E43C00B1402A /* ScannerViewControllerDelegate.swift */; };
+		4EDFAC6C2170E43C00B1402A /* ForceTouchRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC582170E43C00B1402A /* ForceTouchRecognizer.swift */; };
+		4EDFAC6D2170E43C00B1402A /* ScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC592170E43C00B1402A /* ScannerViewController.swift */; };
+		4EDFAC6E2170E43C00B1402A /* TargetBraceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC5B2170E43C00B1402A /* TargetBraceView.swift */; };
+		4EDFAC6F2170E43C00B1402A /* TorchPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC5C2170E43C00B1402A /* TorchPickerView.swift */; };
+		4EDFAC702170E43C00B1402A /* DocumentScannerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC5E2170E43C00B1402A /* DocumentScannerDelegate.swift */; };
+		4EDFAC712170E43C00B1402A /* ImageCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC5F2170E43C00B1402A /* ImageCapturer.swift */; };
+		4EDFAC722170E43C00B1402A /* DocumentScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC602170E43C00B1402A /* DocumentScanner.swift */; };
+		4EDFAC732170E43C00B1402A /* AVDocumentScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC612170E43C00B1402A /* AVDocumentScanner.swift */; };
+		4EDFAC742170E43C00B1402A /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4EDFAC632170E43C00B1402A /* Media.xcassets */; };
+		4EDFAC752170E43C00B1402A /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = 4EDFAC642170E43C00B1402A /* .gitkeep */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		4EDFAC3E2170E3E100B1402A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4EDFAC282170E3C500B1402A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4EDFAC322170E3E100B1402A;
+			remoteInfo = YesWeScan;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		4EDFAC332170E3E100B1402A /* YesWeScan.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YesWeScan.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4EDFAC3C2170E3E100B1402A /* YesWeScanTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = YesWeScanTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4EDFAC502170E43C00B1402A /* RectangleFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RectangleFeature.swift; sourceTree = "<group>"; };
+		4EDFAC512170E43C00B1402A /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		4EDFAC522170E43C00B1402A /* [RectangleFeature]+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "[RectangleFeature]+Extensions.swift"; sourceTree = "<group>"; };
+		4EDFAC542170E43C00B1402A /* UIImage+ScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+ScannerViewController.swift"; sourceTree = "<group>"; };
+		4EDFAC552170E43C00B1402A /* ScannerConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScannerConfig.swift; sourceTree = "<group>"; };
+		4EDFAC562170E43C00B1402A /* ScannerViewController+UIElements.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ScannerViewController+UIElements.swift"; sourceTree = "<group>"; };
+		4EDFAC572170E43C00B1402A /* ScannerViewControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScannerViewControllerDelegate.swift; sourceTree = "<group>"; };
+		4EDFAC582170E43C00B1402A /* ForceTouchRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForceTouchRecognizer.swift; sourceTree = "<group>"; };
+		4EDFAC592170E43C00B1402A /* ScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScannerViewController.swift; sourceTree = "<group>"; };
+		4EDFAC5B2170E43C00B1402A /* TargetBraceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetBraceView.swift; sourceTree = "<group>"; };
+		4EDFAC5C2170E43C00B1402A /* TorchPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TorchPickerView.swift; sourceTree = "<group>"; };
+		4EDFAC5E2170E43C00B1402A /* DocumentScannerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentScannerDelegate.swift; sourceTree = "<group>"; };
+		4EDFAC5F2170E43C00B1402A /* ImageCapturer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCapturer.swift; sourceTree = "<group>"; };
+		4EDFAC602170E43C00B1402A /* DocumentScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentScanner.swift; sourceTree = "<group>"; };
+		4EDFAC612170E43C00B1402A /* AVDocumentScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDocumentScanner.swift; sourceTree = "<group>"; };
+		4EDFAC632170E43C00B1402A /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		4EDFAC642170E43C00B1402A /* .gitkeep */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4EDFAC302170E3E100B1402A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4EDFAC392170E3E100B1402A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4EDFAC3D2170E3E100B1402A /* YesWeScan.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4EDFAC272170E3C500B1402A = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC4D2170E43C00B1402A /* Sources */,
+				4EDFAC342170E3E100B1402A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		4EDFAC342170E3E100B1402A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC332170E3E100B1402A /* YesWeScan.framework */,
+				4EDFAC3C2170E3E100B1402A /* YesWeScanTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4EDFAC4D2170E43C00B1402A /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC4E2170E43C00B1402A /* Classes */,
+				4EDFAC622170E43C00B1402A /* Assets */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		4EDFAC4E2170E43C00B1402A /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC4F2170E43C00B1402A /* Maths */,
+				4EDFAC532170E43C00B1402A /* ViewController */,
+				4EDFAC5D2170E43C00B1402A /* Scanner */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		4EDFAC4F2170E43C00B1402A /* Maths */ = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC502170E43C00B1402A /* RectangleFeature.swift */,
+				4EDFAC512170E43C00B1402A /* Operators.swift */,
+				4EDFAC522170E43C00B1402A /* [RectangleFeature]+Extensions.swift */,
+			);
+			path = Maths;
+			sourceTree = "<group>";
+		};
+		4EDFAC532170E43C00B1402A /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC542170E43C00B1402A /* UIImage+ScannerViewController.swift */,
+				4EDFAC552170E43C00B1402A /* ScannerConfig.swift */,
+				4EDFAC562170E43C00B1402A /* ScannerViewController+UIElements.swift */,
+				4EDFAC572170E43C00B1402A /* ScannerViewControllerDelegate.swift */,
+				4EDFAC582170E43C00B1402A /* ForceTouchRecognizer.swift */,
+				4EDFAC592170E43C00B1402A /* ScannerViewController.swift */,
+				4EDFAC5A2170E43C00B1402A /* Custom Views */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		4EDFAC5A2170E43C00B1402A /* Custom Views */ = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC5B2170E43C00B1402A /* TargetBraceView.swift */,
+				4EDFAC5C2170E43C00B1402A /* TorchPickerView.swift */,
+			);
+			path = "Custom Views";
+			sourceTree = "<group>";
+		};
+		4EDFAC5D2170E43C00B1402A /* Scanner */ = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC5E2170E43C00B1402A /* DocumentScannerDelegate.swift */,
+				4EDFAC5F2170E43C00B1402A /* ImageCapturer.swift */,
+				4EDFAC602170E43C00B1402A /* DocumentScanner.swift */,
+				4EDFAC612170E43C00B1402A /* AVDocumentScanner.swift */,
+			);
+			path = Scanner;
+			sourceTree = "<group>";
+		};
+		4EDFAC622170E43C00B1402A /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				4EDFAC632170E43C00B1402A /* Media.xcassets */,
+				4EDFAC642170E43C00B1402A /* .gitkeep */,
+			);
+			path = Assets;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		4EDFAC2E2170E3E100B1402A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		4EDFAC322170E3E100B1402A /* YesWeScan */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4EDFAC452170E3E100B1402A /* Build configuration list for PBXNativeTarget "YesWeScan" */;
+			buildPhases = (
+				4EDFAC2E2170E3E100B1402A /* Headers */,
+				4EDFAC2F2170E3E100B1402A /* Sources */,
+				4EDFAC302170E3E100B1402A /* Frameworks */,
+				4EDFAC312170E3E100B1402A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = YesWeScan;
+			productName = YesWeScan;
+			productReference = 4EDFAC332170E3E100B1402A /* YesWeScan.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4EDFAC3B2170E3E100B1402A /* YesWeScanTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4EDFAC482170E3E100B1402A /* Build configuration list for PBXNativeTarget "YesWeScanTests" */;
+			buildPhases = (
+				4EDFAC382170E3E100B1402A /* Sources */,
+				4EDFAC392170E3E100B1402A /* Frameworks */,
+				4EDFAC3A2170E3E100B1402A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4EDFAC3F2170E3E100B1402A /* PBXTargetDependency */,
+			);
+			name = YesWeScanTests;
+			productName = YesWeScanTests;
+			productReference = 4EDFAC3C2170E3E100B1402A /* YesWeScanTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4EDFAC282170E3C500B1402A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1000;
+				LastUpgradeCheck = 1000;
+				TargetAttributes = {
+					4EDFAC322170E3E100B1402A = {
+						CreatedOnToolsVersion = 10.0;
+					};
+					4EDFAC3B2170E3E100B1402A = {
+						CreatedOnToolsVersion = 10.0;
+					};
+				};
+			};
+			buildConfigurationList = 4EDFAC2B2170E3C500B1402A /* Build configuration list for PBXProject "YesWeScan" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 4EDFAC272170E3C500B1402A;
+			productRefGroup = 4EDFAC342170E3E100B1402A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4EDFAC322170E3E100B1402A /* YesWeScan */,
+				4EDFAC3B2170E3E100B1402A /* YesWeScanTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4EDFAC312170E3E100B1402A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4EDFAC742170E43C00B1402A /* Media.xcassets in Resources */,
+				4EDFAC752170E43C00B1402A /* .gitkeep in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4EDFAC3A2170E3E100B1402A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4EDFAC2F2170E3E100B1402A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4EDFAC6A2170E43C00B1402A /* ScannerViewController+UIElements.swift in Sources */,
+				4EDFAC732170E43C00B1402A /* AVDocumentScanner.swift in Sources */,
+				4EDFAC6E2170E43C00B1402A /* TargetBraceView.swift in Sources */,
+				4EDFAC652170E43C00B1402A /* RectangleFeature.swift in Sources */,
+				4EDFAC672170E43C00B1402A /* [RectangleFeature]+Extensions.swift in Sources */,
+				4EDFAC712170E43C00B1402A /* ImageCapturer.swift in Sources */,
+				4EDFAC702170E43C00B1402A /* DocumentScannerDelegate.swift in Sources */,
+				4EDFAC662170E43C00B1402A /* Operators.swift in Sources */,
+				4EDFAC6F2170E43C00B1402A /* TorchPickerView.swift in Sources */,
+				4EDFAC6D2170E43C00B1402A /* ScannerViewController.swift in Sources */,
+				4EDFAC682170E43C00B1402A /* UIImage+ScannerViewController.swift in Sources */,
+				4EDFAC6B2170E43C00B1402A /* ScannerViewControllerDelegate.swift in Sources */,
+				4EDFAC722170E43C00B1402A /* DocumentScanner.swift in Sources */,
+				4EDFAC692170E43C00B1402A /* ScannerConfig.swift in Sources */,
+				4EDFAC6C2170E43C00B1402A /* ForceTouchRecognizer.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4EDFAC382170E3E100B1402A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		4EDFAC3F2170E3E100B1402A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4EDFAC322170E3E100B1402A /* YesWeScan */;
+			targetProxy = 4EDFAC3E2170E3E100B1402A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		4EDFAC2C2170E3C500B1402A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		4EDFAC2D2170E3C500B1402A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		4EDFAC462170E3E100B1402A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = FCNMCC2Y82;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = de.adorsys.ios.YesWeScan;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4EDFAC472170E3E100B1402A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = FCNMCC2Y82;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = de.adorsys.ios.YesWeScan;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		4EDFAC492170E3E100B1402A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = FCNMCC2Y82;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = YesWeScanTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = de.adorsys.ios.YesWeScanTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4EDFAC4A2170E3E100B1402A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = FCNMCC2Y82;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = YesWeScanTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = de.adorsys.ios.YesWeScanTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4EDFAC2B2170E3C500B1402A /* Build configuration list for PBXProject "YesWeScan" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4EDFAC2C2170E3C500B1402A /* Debug */,
+				4EDFAC2D2170E3C500B1402A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4EDFAC452170E3E100B1402A /* Build configuration list for PBXNativeTarget "YesWeScan" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4EDFAC462170E3E100B1402A /* Debug */,
+				4EDFAC472170E3E100B1402A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4EDFAC482170E3E100B1402A /* Build configuration list for PBXNativeTarget "YesWeScanTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4EDFAC492170E3E100B1402A /* Debug */,
+				4EDFAC4A2170E3E100B1402A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4EDFAC282170E3C500B1402A /* Project object */;
+}

--- a/YesWeScan.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/YesWeScan.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:YesWeScan.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/YesWeScan.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/YesWeScan.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/YesWeScan.xcodeproj/xcshareddata/xcschemes/YesWeScan.xcscheme
+++ b/YesWeScan.xcodeproj/xcshareddata/xcschemes/YesWeScan.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4EDFAC322170E3E100B1402A"
+               BuildableName = "YesWeScan.framework"
+               BlueprintName = "YesWeScan"
+               ReferencedContainer = "container:YesWeScan.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4EDFAC3B2170E3E100B1402A"
+               BuildableName = "YesWeScanTests.xctest"
+               BlueprintName = "YesWeScanTests"
+               ReferencedContainer = "container:YesWeScan.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4EDFAC322170E3E100B1402A"
+            BuildableName = "YesWeScan.framework"
+            BlueprintName = "YesWeScan"
+            ReferencedContainer = "container:YesWeScan.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4EDFAC322170E3E100B1402A"
+            BuildableName = "YesWeScan.framework"
+            BlueprintName = "YesWeScan"
+            ReferencedContainer = "container:YesWeScan.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4EDFAC322170E3E100B1402A"
+            BuildableName = "YesWeScan.framework"
+            BlueprintName = "YesWeScan"
+            ReferencedContainer = "container:YesWeScan.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Description

Following the steps at [the carthage manual][1], this adds Carthage Compatibility.
In order to do this, I had to add a `YesWeScan.xcodeproj` at the root of the project that contains the framework to be built.

To verify this works, I ran the command `carthage build --archive`, which ensures that the module can be built.

Next steps will be to upload the pre-built archives to GitHub so users won't have to rebuild the framework every time.

[1]: https://github.com/Carthage/Carthage#supporting-carthage-for-your-framework