### PR TITLE
Fix Carthage

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - SwiftLint (0.27.0)
   - TOCropViewController (2.3.8)
-  - YesWeScan (1.0.2)
+  - YesWeScan (1.0.3)
 
 DEPENDENCIES:
   - SwiftLint
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
   TOCropViewController: 0a075f02c253e88095143bbac7b013fc6fba5090
-  YesWeScan: 5825de3e8b5106ca65554ddb1307bb8dc6caf017
+  YesWeScan: a3eda0862e6928da4d7e1c8c8a60270ed880576c
 
 PODFILE CHECKSUM: 8a020456342e9d51e5b5d38fd3c327a62252d10b
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,22 @@ This pod contains a ready to use view controller for document scanning. Yes we s
 <img src="Images/preview.GIF" width="250" max-width="50%" alt="Demo" />
 
 ## Installation
-YesWeScan is available through [CocoaPods](http://cocoapods.org). To
-install it, simply add the following line to your Podfile:
+
+#### Cocoapods
+
+YesWeScan is available through [CocoaPods](http://cocoapods.org).
+To install it, simply add the following line to your `Podfile`:
 
 ```ruby
 pod 'YesWeScan'
 ```
+
+#### Carthage
+
+YesWeScan is also available via [Carthage](https://github.com/Carthage/Carthage).
+Add the following line to your `Cartfile`:
+
+`github "adorsys/document-scanner-ios"`
 
 ## Using this Pod
 

--- a/Sources/Classes/ViewController/UIImage+ScannerViewController.swift
+++ b/Sources/Classes/ViewController/UIImage+ScannerViewController.swift
@@ -8,15 +8,9 @@
 import UIKit
 
 extension UIImage {
-    static let buttonImage = loadAsset(named: "CaptureButton")
+    static let buttonImage = UIImage(named: "CaptureButton")
 
-    static let targetBracesToggleImage = loadAsset(named: "FocusIndicator")
+    static let targetBracesToggleImage = UIImage(named: "FocusIndicator")
 
-    static let torchImage = loadAsset(named: "Torch")
-
-    private static func loadAsset(named: String) -> UIImage {
-        let outerBundle = Bundle(for: ScannerViewController.self)
-        let bundle = Bundle(url: outerBundle.url(forResource: "Assets", withExtension: "bundle")!)
-        return UIImage(named: named, in: bundle, compatibleWith: nil)!
-    }
+    static let torchImage = UIImage(named: "Torch")
 }

--- a/Tests/AssetsAccessTests.swift
+++ b/Tests/AssetsAccessTests.swift
@@ -1,0 +1,18 @@
+//
+//  AssetsAccessTests.swift
+//  YesWeScanTests
+//
+//  Created by Xaver Lohmüller on 15.10.18.
+//
+
+import XCTest
+@testable import YesWeScan
+
+class AssetsAccessTests: XCTestCase {
+
+    func testAssetsCanBeAccessed() {
+        XCTAssertNoThrow(UIImage.buttonImage)
+        XCTAssertNoThrow(UIImage.targetBracesToggleImage)
+        XCTAssertNoThrow(UIImage.torchImage)
+    }
+}

--- a/Tests/Supporting Files/Info.plist
+++ b/Tests/Supporting Files/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/YesWeScan.podspec
+++ b/YesWeScan.podspec
@@ -32,4 +32,8 @@ This pod contains a ready to use view controller for document scanning.
   s.source_files = 'Sources/Classes/**/*'
   s.resources = 'Sources/Assets/**/*'
   s.frameworks = 'AVFoundation'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/*.swift'
+  end
 end

--- a/YesWeScan.podspec
+++ b/YesWeScan.podspec
@@ -30,8 +30,6 @@ This pod contains a ready to use view controller for document scanning.
   s.swift_version = '4.2'
 
   s.source_files = 'Sources/Classes/**/*'
-  s.resource_bundles = {
-    'Assets' => ['Sources/Assets/**/*']
-  }
+  s.resources = 'Sources/Assets/**/*'
   s.frameworks = 'AVFoundation'
 end

--- a/YesWeScan.xcodeproj/project.pbxproj
+++ b/YesWeScan.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4E7C3E7B2174AC8C00AA4E31 /* AssetsAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7C3E7A2174AC8C00AA4E31 /* AssetsAccessTests.swift */; };
+		4E7C3E7C2174B12200AA4E31 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4EDFAC632170E43C00B1402A /* Media.xcassets */; };
 		4EDFAC3D2170E3E100B1402A /* YesWeScan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EDFAC332170E3E100B1402A /* YesWeScan.framework */; };
 		4EDFAC652170E43C00B1402A /* RectangleFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC502170E43C00B1402A /* RectangleFeature.swift */; };
 		4EDFAC662170E43C00B1402A /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC512170E43C00B1402A /* Operators.swift */; };
@@ -23,8 +25,6 @@
 		4EDFAC712170E43C00B1402A /* ImageCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC5F2170E43C00B1402A /* ImageCapturer.swift */; };
 		4EDFAC722170E43C00B1402A /* DocumentScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC602170E43C00B1402A /* DocumentScanner.swift */; };
 		4EDFAC732170E43C00B1402A /* AVDocumentScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFAC612170E43C00B1402A /* AVDocumentScanner.swift */; };
-		4EDFAC742170E43C00B1402A /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4EDFAC632170E43C00B1402A /* Media.xcassets */; };
-		4EDFAC752170E43C00B1402A /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = 4EDFAC642170E43C00B1402A /* .gitkeep */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4E7C3E7A2174AC8C00AA4E31 /* AssetsAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsAccessTests.swift; sourceTree = "<group>"; };
 		4EDFAC332170E3E100B1402A /* YesWeScan.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YesWeScan.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4EDFAC3C2170E3E100B1402A /* YesWeScanTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = YesWeScanTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4EDFAC502170E43C00B1402A /* RectangleFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RectangleFeature.swift; sourceTree = "<group>"; };
@@ -56,7 +57,6 @@
 		4EDFAC602170E43C00B1402A /* DocumentScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentScanner.swift; sourceTree = "<group>"; };
 		4EDFAC612170E43C00B1402A /* AVDocumentScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDocumentScanner.swift; sourceTree = "<group>"; };
 		4EDFAC632170E43C00B1402A /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
-		4EDFAC642170E43C00B1402A /* .gitkeep */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,10 +78,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4E7C3E792174AC7800AA4E31 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				4E7C3E7A2174AC8C00AA4E31 /* AssetsAccessTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
 		4EDFAC272170E3C500B1402A = {
 			isa = PBXGroup;
 			children = (
 				4EDFAC4D2170E43C00B1402A /* Sources */,
+				4E7C3E792174AC7800AA4E31 /* Tests */,
 				4EDFAC342170E3E100B1402A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -162,7 +171,6 @@
 			isa = PBXGroup;
 			children = (
 				4EDFAC632170E43C00B1402A /* Media.xcassets */,
-				4EDFAC642170E43C00B1402A /* .gitkeep */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
@@ -230,6 +238,7 @@
 					};
 					4EDFAC3B2170E3E100B1402A = {
 						CreatedOnToolsVersion = 10.0;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -256,8 +265,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4EDFAC742170E43C00B1402A /* Media.xcassets in Resources */,
-				4EDFAC752170E43C00B1402A /* .gitkeep in Resources */,
+				4E7C3E7C2174B12200AA4E31 /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -297,6 +305,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4E7C3E7B2174AC8C00AA4E31 /* AssetsAccessTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -535,7 +544,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = YesWeScanTests/Info.plist;
+				INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -603,7 +612,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = YesWeScanTests/Info.plist;
+				INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## Description

I added installation instructions for Carthage users.

Checking this, I noticed that currently v1.0.3 crashes due to the resource bundle handling when installed with Carthage.

I read up on the specifications of .podspec files and realized that `s.resource_bundles` is the wrong abstraction for including asset catalogs: `s.resources` is a better fit for our use case.

To debug this, I added a trivial test case. Instead of deleting it afterwards, I kept it to lay the groundwork for further testing.
The test case now runs every time `pod lib lint` is executed (which is part of our Travis checks).