### PR TITLE
Load assets from correct bundle

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - SwiftLint (0.27.0)
   - TOCropViewController (2.3.8)
-  - YesWeScan (1.0.3)
+  - YesWeScan (1.0.4)
 
 DEPENDENCIES:
   - SwiftLint
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
   TOCropViewController: 0a075f02c253e88095143bbac7b013fc6fba5090
-  YesWeScan: a3eda0862e6928da4d7e1c8c8a60270ed880576c
+  YesWeScan: a292270f4a2a94938efc3e54acb55cb887f0a556
 
 PODFILE CHECKSUM: 8a020456342e9d51e5b5d38fd3c327a62252d10b
 

--- a/Sources/Classes/ViewController/UIImage+ScannerViewController.swift
+++ b/Sources/Classes/ViewController/UIImage+ScannerViewController.swift
@@ -7,10 +7,14 @@
 
 import UIKit
 
+private var bundle: Bundle {
+    return Bundle(for: ScannerViewController.self)
+}
+
 extension UIImage {
-    static let buttonImage = UIImage(named: "CaptureButton")
+    static let buttonImage = UIImage(named: "CaptureButton", in: bundle, compatibleWith: nil)
 
-    static let targetBracesToggleImage = UIImage(named: "FocusIndicator")
+    static let targetBracesToggleImage = UIImage(named: "FocusIndicator", in: bundle, compatibleWith: nil)
 
-    static let torchImage = UIImage(named: "Torch")
+    static let torchImage = UIImage(named: "Torch", in: bundle, compatibleWith: nil)
 }


### PR DESCRIPTION
## Description

The pull request that changed the handling of resources of the pod accidentally broke asset loading when the pod isn't the main target.

This pull request restores it:

| Before | After
| --- | --- |
| ![img_0590](https://user-images.githubusercontent.com/16212751/47150747-dc434d80-d2d7-11e8-8118-abccbd7c7903.PNG) | ![img_0589](https://user-images.githubusercontent.com/16212751/47150744-db122080-d2d7-11e8-9acf-6f859225c611.PNG) |
