### PR TITLE
Adds a progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* New: Track progress of the current scan
+
 ## 1.2.0
 
 * New: You can set the quality of the scanner for automatic captures (by @msztech)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The following options are available:
 + `.targetBraces`: A button to toggle targeting braces
 + `.torch`: A button for controlling the torch
 + `.manualCapture`: A manual camera shutter
++ `.progressBar`: Show a progress bar for the current scan
 
 The default value here is `.all`
 

--- a/Sources/Classes/Scanner/AVDocumentScanner.swift
+++ b/Sources/Classes/Scanner/AVDocumentScanner.swift
@@ -3,8 +3,12 @@ import UIKit
 
 final class AVDocumentScanner: NSObject {
     var lastTorchLevel: Float = 0
-    var desiredJitter: CGFloat = 100
+    var desiredJitter: CGFloat = 100 {
+        didSet { progress.completedUnitCount = Int64(desiredJitter) }
+    }
     var featuresRequired: Int = 7
+
+    let progress = Progress()
 
     lazy var previewLayer: CALayer = {
         let layer = AVCaptureVideoPreviewLayer(session: captureSession)
@@ -38,6 +42,7 @@ final class AVDocumentScanner: NSObject {
         captureSession = session
         imageCapturer = ImageCapturer(session: session)
         super.init()
+        progress.completedUnitCount = Int64(desiredJitter)
         output.setSampleBufferDelegate(self, queue: imageQueue)
     }
 
@@ -113,6 +118,7 @@ extension AVDocumentScanner: AVCaptureVideoDataOutputSampleBufferDelegate {
 
         let (smoothed, newFeatures) = feature.smoothed(with: lastFeatures)
         lastFeatures = newFeatures
+        progress.totalUnitCount = Int64(newFeatures.jitter)
 
         if newFeatures.count > featuresRequired,
             newFeatures.jitter < desiredJitter,

--- a/Sources/Classes/Scanner/DocumentScanner.swift
+++ b/Sources/Classes/Scanner/DocumentScanner.swift
@@ -15,6 +15,9 @@ protocol DocumentScanner {
     /// this will have the same bounds as the device's screen
     var previewLayer: CALayer { get }
 
+    /// Indicates the progress of the scan
+    var progress: Progress { get }
+
     /// Manually capture an image in given bounds
     ///
     /// - Parameters:

--- a/Sources/Classes/ViewController/ScannerConfig.swift
+++ b/Sources/Classes/ViewController/ScannerConfig.swift
@@ -10,11 +10,13 @@ public extension ScannerViewController {
         public static let targetBraces = ScannerConfig(rawValue: 1 << 0)
         public static let torch = ScannerConfig(rawValue: 1 << 1)
         public static let manualCapture = ScannerConfig(rawValue: 1 << 2)
+        public static let progressBar = ScannerConfig(rawValue: 1 << 3)
 
         public static let all: ScannerConfig = [
             .targetBraces,
             .torch,
-            .manualCapture
+            .manualCapture,
+            .progressBar
         ]
     }
 }

--- a/Sources/Classes/ViewController/ScannerViewController+UIElements.swift
+++ b/Sources/Classes/ViewController/ScannerViewController+UIElements.swift
@@ -49,6 +49,12 @@ extension ScannerViewController {
                          for: .touchUpInside)
         return button
     }
+
+    func makeProgressBar() -> UIProgressView {
+        let progressBar = UIProgressView()
+        progressBar.translatesAutoresizingMaskIntoConstraints = false
+        return progressBar
+    }
 }
 
 private func blurView() -> UIVisualEffectView {

--- a/Sources/Classes/ViewController/ScannerViewController.swift
+++ b/Sources/Classes/ViewController/ScannerViewController.swift
@@ -10,6 +10,8 @@ import AVFoundation
 
 public final class ScannerViewController: UIViewController {
 
+    private var observer: Any?
+
     public weak var delegate: ScannerViewControllerDelegate?
     public var jitter: CGFloat {
         set { scanner.desiredJitter = newValue }
@@ -40,11 +42,19 @@ public final class ScannerViewController: UIViewController {
         }
     }
 
+    public var progress: Progress {
+        return scanner.progress
+    }
+
     public init(sessionPreset: AVCaptureSession.Preset = .photo, config: ScannerConfig = .all) {
         self.sessionPreset = sessionPreset
         super.init(nibName: nil, bundle: nil)
         setupUI(config: config)
+        observer = progress.observe(\.fractionCompleted) { progress, _ in
+            print(progress.fractionCompleted)
+        }
     }
+
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) isn't supported")
     }

--- a/Sources/Classes/ViewController/ScannerViewController.swift
+++ b/Sources/Classes/ViewController/ScannerViewController.swift
@@ -55,6 +55,7 @@ public final class ScannerViewController: UIViewController {
                 self?.progressBar?.setProgress(Float(progress.fractionCompleted), animated: true)
             }
         }
+        edgesForExtendedLayout.remove(.top)
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -165,7 +166,7 @@ public final class ScannerViewController: UIViewController {
             view.addSubview(progressBar)
             NSLayoutConstraint.activate([
                 progressBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                progressBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                progressBar.topAnchor.constraint(equalTo: view.topAnchor),
                 progressBar.trailingAnchor.constraint(equalTo: view.trailingAnchor)
             ])
         }

--- a/Sources/Classes/ViewController/ScannerViewController.swift
+++ b/Sources/Classes/ViewController/ScannerViewController.swift
@@ -50,8 +50,10 @@ public final class ScannerViewController: UIViewController {
         self.sessionPreset = sessionPreset
         super.init(nibName: nil, bundle: nil)
         setupUI(config: config)
-        observer = progress.observe(\.fractionCompleted) { progress, _ in
-            print(progress.fractionCompleted)
+        observer = progress.observe(\.fractionCompleted) { [weak self] progress, _ in
+            DispatchQueue.main.async {
+                self?.progressBar?.setProgress(Float(progress.fractionCompleted), animated: true)
+            }
         }
     }
 
@@ -63,6 +65,7 @@ public final class ScannerViewController: UIViewController {
     @IBOutlet private weak var targetView: UIView!
     @IBOutlet private weak var targetButton: UIView!
     @IBOutlet private weak var torchButton: UIView!
+    @IBOutlet private weak var progressBar: UIProgressView!
 
     private lazy var scanner: DocumentScanner & TorchPickerViewDelegate = {
         AVDocumentScanner(sessionPreset: sessionPreset, delegate: self)
@@ -154,6 +157,17 @@ public final class ScannerViewController: UIViewController {
                     .constraint(equalTo: torch.bottomAnchor, constant: 8)
                     .isActive = true
             }
+        }
+
+        if config.contains(.progressBar) {
+            let progressBar = makeProgressBar()
+            self.progressBar = progressBar
+            view.addSubview(progressBar)
+            NSLayoutConstraint.activate([
+                progressBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                progressBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                progressBar.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            ])
         }
     }
 


### PR DESCRIPTION
## Description

(Addresses #22)

Exposes a [`Progress`][nsprogress] object on the `ScannerViewController` to track scanning status.

The progress is calculated using the jitter values, so the implementation looks a bit weird
(because the `completedUnitCount` is fixed and the `totalUnitCount` varies).

Also, there is now a `UIProgressView` in the view controller to show this progress.

[nsprogress]: https://developer.apple.com/documentation/foundation/progress