### PR TITLE
Install bundler on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: swift
 osx_image: xcode10
-env: LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+env: LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 
+
+before_install:
+  - gem update --system
+  - gem install bundler
 install:
   - bundle install
 script:


### PR DESCRIPTION
Our current build status is `error`. This will be fixed with installing bundler in `before_script` on CI.

See https://docs.travis-ci.com/user/languages/ruby/#bundler-20 for more information.