### PR TITLE
Crash due to race condition under certain circumstances

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - YesWeScan (from `../`)
 
 SPEC REPOS:
-  trunk:
+  https://cdn.cocoapods.org/:
     - SwiftLint
     - TOCropViewController
 

--- a/Sources/YesWeScan/Scanner/AVDocumentScanner.swift
+++ b/Sources/YesWeScan/Scanner/AVDocumentScanner.swift
@@ -137,11 +137,13 @@ extension AVDocumentScanner: DocumentScanner {
         imageCapturer.captureImage(in: bounds, completion: completion)
     }
     public func start() {
-        guard !captureSession.isRunning else {
-            return
+        imageQueue.async {
+            guard !self.captureSession.isRunning else {
+                return
+            }
+            self.captureSession.startRunning()
+            self.isStopped = false
         }
-        captureSession.startRunning()
-        isStopped = false
     }
     public func pause() {
         isStopped = true


### PR DESCRIPTION
I learned from our crash logging that sometimes the Scanner crahses with following message:

`*** -[AVCaptureSession startRunning] startRunning may not be called between calls to beginConfiguration and commitConfiguration`

`AVDocumentScanner.swift - Zeile 144
protocol witness for DocumentScanner.start() in conformance AVDocumentScanner + 144`

I can't reproduce the crash but it seems that the call of `captureSession.startRunning()` outside of the `imageQueue` is causing the crash. Unfortunately I'm not able to test my fix but I have high hopes ;)