### PR TITLE
Hide torch on devices without torch

### DIFF
--- a/Sources/YesWeScan/Scanner/AVDocumentScanner.swift
+++ b/Sources/YesWeScan/Scanner/AVDocumentScanner.swift
@@ -7,7 +7,7 @@ public final class AVDocumentScanner: NSObject {
         didSet { progress.completedUnitCount = Int64(desiredJitter) }
     }
     public var featuresRequired: Int = 7
-
+    public var hasTorch: Bool = false
     public let progress = Progress()
 
     public lazy var previewLayer: CALayer = {
@@ -21,6 +21,7 @@ public final class AVDocumentScanner: NSObject {
         super.init()
 
         progress.completedUnitCount = Int64(desiredJitter)
+        hasTorch = device?.hasTorch ?? false
 
         imageQueue.async {
             guard let device = self.device,
@@ -61,7 +62,7 @@ public final class AVDocumentScanner: NSObject {
             mediaType: .video,
             position: .back
             ).devices
-            .first { $0.hasTorch }
+            .first
     }()
 
     private lazy var output: AVCaptureVideoDataOutput = {

--- a/Sources/YesWeScan/ViewController/Custom Views/TorchPickerView.swift
+++ b/Sources/YesWeScan/ViewController/Custom Views/TorchPickerView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 protocol TorchPickerViewDelegate: AnyObject {
     var lastTorchLevel: Float { get }
+    var hasTorch: Bool { get }
 
     func toggleTorch()
     func didPickTorchLevel(_ level: Float)

--- a/Sources/YesWeScan/ViewController/ScannerViewController.swift
+++ b/Sources/YesWeScan/ViewController/ScannerViewController.swift
@@ -97,6 +97,12 @@ public final class ScannerViewController: UIViewController {
 
     private func setupUI(config: ScannerConfig) {
 
+        var config = config
+        // Some devices have no build-in torch
+        if !scanner.hasTorch {
+            config.remove(.torch)
+        }
+
         if config.contains(.manualCapture) {
             let button = takePhotoButtonView()
             view.addSubview(button)
@@ -301,6 +307,7 @@ extension ScannerViewController: DocumentScannerDelegate {
 
 extension ScannerViewController: TorchPickerViewDelegate {
     var lastTorchLevel: Float { return scanner.lastTorchLevel }
+    var hasTorch: Bool { return scanner.hasTorch }
 
     func didPickTorchLevel(_ level: Float) {
         guard level != lastTorchLevel else { return }


### PR DESCRIPTION
On some devices there is no build-in torch. This results in a not working scanner. We now just don't display the torch button, when there is no torch.