### PR TITLE
Misaligned feature's overlay

### DIFF
--- a/Sources/YesWeScan/Scanner/AVDocumentScanner.swift
+++ b/Sources/YesWeScan/Scanner/AVDocumentScanner.swift
@@ -101,7 +101,7 @@ extension AVDocumentScanner: AVCaptureVideoDataOutputSampleBufferDelegate {
             .max()
             .map {
                 $0.normalized(source: image.extent.size,
-                              target: UIScreen.main.bounds.size)
+                              target: previewLayer.bounds.size)
             }
             .flatMap { smooth(feature: $0, in: image) }
 


### PR DESCRIPTION
FIx a bug that cause misaligned overlay, if the preview layer has not the screen size.
I think that also `ImageCapturer.swift` at line 51 should be modified in the same way, maybe adding a sourceSize parameter in the function.

```
let processed: CIImage
    if let feature = feature {
        let normalized = feature.normalized(source: UIScreen.main.bounds.size, 
                                            target: image.extent.size)
```